### PR TITLE
[RFC] Add all neighbors query

### DIFF
--- a/include/routingkit/geo_position_to_node.h
+++ b/include/routingkit/geo_position_to_node.h
@@ -24,6 +24,7 @@ public:
 	};
 
 	NearestNeighborhoodQueryResult find_nearest_neighbor_within_radius(float query_latitude, float query_longitude, float query_radius)const;
+    std::vector<unsigned> find_nearest_neighbors_within_radius(float query_latitude, float query_longitude, float query_radius)const;
 
 
 // private:


### PR DESCRIPTION
The function find_nearest_neighbor_within_radius() returns only the closest
neighbor. This patch add the ability to return a vector of all the closest
neighbors within a radius.

The two functions are pretty much identical and a refactoring would be
necessary.

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.com>