### PR TITLE
Replace div with mul by the inverse in geo_dist

### DIFF
--- a/src/geo_dist.cpp
+++ b/src/geo_dist.cpp
@@ -10,20 +10,21 @@ double geo_dist(double a_lat, double a_lon, double b_lat, double b_lon){
 
 	const double pi = 3.14159265359;
 	const double R = 6371000.0; // earth radius in meter
+	const double inv_180 = 1.0 / 180;
 
-	a_lat /= 180;
+	a_lat *= inv_180;
 	a_lat *= pi;
-	b_lat /= 180;
+	b_lat *= inv_180;
 	b_lat *= pi;
-	a_lon /= 180;
+	a_lon *= inv_180;
 	a_lon *= pi;
-	b_lon /= 180;
+	b_lon *= inv_180;
 	b_lon *= pi;
-	
+
 	double dlat = b_lat - a_lat;
 	double dlon = b_lon - a_lon;
 
-	double a_ = sin(dlat/2.0) * sin(dlat/2.0) + sin(dlon/2.0) * sin(dlon/2.0) * cos(a_lat) * cos(b_lat);
+	double a_ = sin(dlat*0.5) * sin(dlat*0.5) + sin(dlon*0.5) * sin(dlon*0.5) * cos(a_lat) * cos(b_lat);
 	double c = 2 * atan2(sqrt(a_), sqrt(1-a_));
 	return R * c;
 }


### PR DESCRIPTION
Multiplication is an order of magnitude faster than division. In this case,
the divisor is constant, meaning that it can be replace with a
multiplication by the inverse. The result will be practicaly the same
(float arithmetic is not commutative, therefore may not be strictly equal).

This patch improves the performance of a query on a GeoPositionToNode is
improved by about 9% on an Intel i7-4600U.

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.com>