### PR TITLE
Feature original arc

### DIFF
--- a/include/routingkit/osm_graph_builder.h
+++ b/include/routingkit/osm_graph_builder.h
@@ -36,8 +36,12 @@ struct OSMRoutingGraph{
 	std::vector<uint32_t>head;
 	std::vector<uint32_t>way;
 	std::vector<uint32_t>geo_distance;
+	std::vector<uint32_t>arc_path_head;
+	std::vector<uint32_t>arc_path_tail;
 	std::vector<float>latitude;
 	std::vector<float>longitude;
+	std::vector<float>arc_path_latitude;
+	std::vector<float>arc_path_longitude;
 
 	unsigned node_count()const{
 		return first_out.size()-1;

--- a/include/routingkit/osm_simple.h
+++ b/include/routingkit/osm_simple.h
@@ -14,8 +14,12 @@ struct SimpleOSMCarRoutingGraph{
 	std::vector<uint32_t>head;
 	std::vector<uint32_t>travel_time;
 	std::vector<uint32_t>geo_distance;
+	std::vector<uint32_t>arc_path_head;
+	std::vector<uint32_t>arc_path_tail;
 	std::vector<float>latitude;
 	std::vector<float>longitude;
+	std::vector<float>arc_path_latitude;
+	std::vector<float>arc_path_longitude;
 
 	unsigned node_count() const {
 		return first_out.size()-1;

--- a/src/osm_graph_builder.cpp
+++ b/src/osm_graph_builder.cpp
@@ -27,7 +27,7 @@ OSMRoutingIDMapping load_osm_id_mapping_from_pbf(
 	std::function<void(std::string)>log_message
 ){
 	OSMRoutingIDMapping map;
-	
+
 	log_message("Scanning OSM PBF data to determine IDs");
 	long long timer = -get_micro_time();
 
@@ -78,14 +78,14 @@ OSMRoutingIDMapping load_osm_id_mapping_from_pbf(
 	);
 	timer += get_micro_time();
 	log_message("Finished scan, needed "+std::to_string(timer)+"musec.");
-	
+
 	log_message("OSM ID range goes up to "+std::to_string(map.is_routing_node.size()) +" for routing nodes.");
 	log_message("OSM ID range goes up to "+std::to_string(map.is_modelling_node.size()) +" for modelling nodes.");
 	log_message("OSM ID range goes up to "+std::to_string(map.is_routing_way.size()) +" for routing ways.");
 	log_message("Found "+std::to_string(map.is_routing_node.population_count()) +" routing nodes.");
 	log_message("Found "+std::to_string(map.is_modelling_node.population_count()) +" modelling nodes.");
 	log_message("Found "+std::to_string(map.is_routing_way.population_count()) +" routing ways.");
-	
+
 	return map;
 }
 
@@ -114,7 +114,7 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 
 	timer += get_micro_time();
 	log_message("Finished, needed "+std::to_string(timer)+"musec.");
-	
+
 	auto on_new_arc = [&](unsigned x, unsigned y, unsigned dist, unsigned routing_way_id){
 		tail.push_back(x);
 		routing_graph.head.push_back(y);
@@ -155,7 +155,7 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 						);
 
 						modelling_id_of_previous_modelling_node = modelling_id_of_current_node;
-					
+
 						unsigned routing_id_of_current_node = routing_node.to_local(node_list[i], invalid_id);
 						if(routing_id_of_current_node != invalid_id){
 
@@ -175,7 +175,7 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 
 							dist_since_last_routing_node = 0;
 							routing_id_of_last_routing_node = routing_id_of_current_node;
-						}				
+						}
 					}
 				}
 			}
@@ -203,19 +203,19 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 		routing_graph.first_out = invert_vector(tail, node_count);
 	}
 	timer += get_micro_time();
-	
+
 	log_message("Finished sorting, needed "+std::to_string(timer)+"musec.");
-	
+
 	log_message("Start computing modelling to routing node mapping");
 	timer = -get_micro_time();
 
 	BitVector modelling_node_is_routing_node(modelling_node.local_id_count(), false);
 	for(unsigned r=0; r < routing_node.local_id_count(); ++r)
 		modelling_node_is_routing_node.set(modelling_node.to_local(routing_node.to_global(r)));
-	
+
 	timer += get_micro_time();
 	log_message("Finished, needed "+std::to_string(timer)+"musec.");
-	
+
 
 	log_message("Start reducing geographic positions to routing nodes");
 	timer = -get_micro_time();
@@ -225,7 +225,7 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 
 	timer += get_micro_time();
 	log_message("Finished, needed "+std::to_string(timer)+"musec.");
-	
+
 	return routing_graph; // NVRO
 }
 

--- a/src/osm_simple.cpp
+++ b/src/osm_simple.cpp
@@ -45,7 +45,11 @@ SimpleOSMCarRoutingGraph simple_load_osm_car_routing_graph_from_pbf(
 	ret.latitude = std::move(routing_graph.latitude);
 	ret.longitude = std::move(routing_graph.longitude);
 	ret.travel_time = ret.geo_distance;
-	
+	ret.arc_path_head = std::move(routing_graph.arc_path_head);
+	ret.arc_path_tail = std::move(routing_graph.arc_path_tail);
+	ret.arc_path_latitude = std::move(routing_graph.arc_path_latitude);
+	ret.arc_path_longitude = std::move(routing_graph.arc_path_longitude);
+
 	for(unsigned a=0; a<ret.travel_time.size(); ++a){
 		ret.travel_time[a] *= 18;
 		ret.travel_time[a] /= way_speed[routing_graph.way[a]];


### PR DESCRIPTION
I was about to start a mail to @ben-strasser with the subject "Breaking my head on routingkit". When writing the email, my last resort in debugging, I stumbled upon the solution that I had been missing for the past days. In https://github.com/bliksemlabs/RoutingKit/blob/feature-original-arc/src/osm_graph_builder.cpp#L231 I assumed the arc indexes would remain in the initial order, which they didn't.

So this is my attempt to come up with a solution for issue #8. It is almost as naive as possible, but it does elegantly solve the reverse order case. Other then that: all routing nodes are duplicated in the arc. I am currently trying to use this duplication in my advantage as a short term solution for #19 case 1.

![shape](https://cloud.githubusercontent.com/assets/502394/20949085/dc495f46-bc17-11e6-8d11-044683e9e6c4.png)
