### PR TITLE
The current master branch does not compile.

### DIFF
--- a/src/test_contraction_hierarchy_extra_weight.cpp
+++ b/src/test_contraction_hierarchy_extra_weight.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <random>
 
 #include "expect.h"
 


### PR DESCRIPTION
I wanted to try @ben-strasser's work in #9 but ended up in fixing master.

This commit adds an include to fix the error during the compilation regarding:

error: ‘minstd_rand’ is not a member of ‘std’