### PR TITLE
Fix out of bounds access in osm_decoder

### DIFF
--- a/src/osm_decoder.cpp
+++ b/src/osm_decoder.cpp
@@ -122,7 +122,7 @@ namespace{
 							if(key_id == 1){
 								unsigned len = str_end - str_begin;
 								if(len > sizeof(block_type)-1)
-									len = sizeof(block_type);
+									len = sizeof(block_type)-1;
 								memcpy(block_type, str_begin, len);
 								block_type[len] = '\0';
 							}


### PR DESCRIPTION
cppcheck reported:

[src/osm_decoder.cpp:127]: (error) Array 'block_type[16]' accessed at index 16, which is out of bounds.

...and I suggest you would add cppcheck to the travis script as well ;-)