### PR TITLE
Add support for OSM tag duration for ferries.

### DIFF
--- a/include/routingkit/osm_profile.h
+++ b/include/routingkit/osm_profile.h
@@ -11,6 +11,11 @@
 namespace RoutingKit{
 
 bool is_osm_way_used_by_cars(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message = nullptr);
+// Returns either
+//   - speed in km/h
+//   - absolute seconds needed to traverse way
+// If absolute seconds are returned the result is marked with ABSOLUTE_TIME flag.
+const unsigned ABSOLUTE_TIME = 0x80000000;
 unsigned get_osm_way_speed(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message = nullptr);
 std::string get_osm_way_name(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message = nullptr);
 OSMWayDirectionCategory get_osm_car_direction_category(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message = nullptr);

--- a/include/routingkit/parse_duration.h
+++ b/include/routingkit/parse_duration.h
@@ -1,0 +1,62 @@
+#ifndef ROUTING_KIT_PARSE_DURATION_H
+#define ROUTING_KIT_PARSE_DURATION_H
+#include <string>
+#include <regex>
+
+namespace RoutingKit{
+unsigned match_duration(const std::string& input, const std::regex& re, unsigned default_value) {
+	std::smatch match;
+	std::regex_search(input, match, re);
+	if (match.empty()) {
+		return default_value;
+	}
+	std::vector<double> vec = {0,0,0,0,0,0};
+	for (size_t i = 1; i < match.size(); ++i) {
+		if (match[i].matched) {
+			std::string str = match[i];
+			str.pop_back(); // remove last character.
+			vec[i-1] = std::stod(str);
+		}
+	}
+	unsigned duration =
+		31556926   * vec[0] +  // years
+		2629744    * vec[1] +  // months
+		86400      * vec[2] +  // days
+		3600       * vec[3] +  // hours
+		60         * vec[4] +  // minutes
+		1          * vec[5];   // seconds
+	if (duration == 0) {
+		return default_value;
+	}
+	return duration;
+}
+
+unsigned parse_duration(const char* duration) {
+	// Simple mm, hh:mm hh:mm:ss duration.
+	static const std::regex simple_a("(\\d\\d)");
+	static const std::regex simple_b("(\\d\\d):(\\d\\d)");
+	static const std::regex simple_c("(\\d\\d):(\\d\\d):(\\d\\d)");
+	// ISO 8601 duration parsing (by https://github.com/sigidagi).
+	static const std::regex has_time_component("^((?!T).)*$");
+	static const std::regex without_time("P([[:d:]]+Y)?([[:d:]]+M)?([[:d:]]+D)?");
+	static const std::regex with_time("P([[:d:]]+Y)?([[:d:]]+M)?([[:d:]]+D)?T([[:d:]]+H)?([[:d:]]+M)?([[:d:]]+S|[[:d:]]+\\.[[:d:]]+S)?");
+
+  std::cmatch match;
+	unsigned result = 600; // Default 10 minutes.
+	if (std::regex_match(duration, match, simple_a)) {
+		result = std::stoi(match[1].str()) * 60;
+	} else if (std::regex_match(duration, match, simple_b)) {
+		result = std::stoi(match[1].str()) * 60 * 60 + stoi(match[2].str()) * 60;
+	} else if (std::regex_match(duration, match, simple_c)) {
+		result = std::stoi(match[1].str()) * 60 * 60 + stoi(match[2].str()) * 60 + stoi(match[3]);
+	} else {
+			if (std::regex_match(duration, has_time_component))
+					result = match_duration(duration, without_time, result);
+			else
+					result = match_duration(duration, with_time, result);
+	}
+	return result;
+}
+} // RoutingKit
+
+#endif

--- a/include/routingkit/parse_duration.h
+++ b/include/routingkit/parse_duration.h
@@ -33,9 +33,9 @@ unsigned match_duration(const std::string& input, const std::regex& re, unsigned
 
 unsigned parse_duration(const char* duration) {
 	// Simple mm, hh:mm hh:mm:ss duration.
-	static const std::regex simple_a("(\\d\\d)");
-	static const std::regex simple_b("(\\d\\d):(\\d\\d)");
-	static const std::regex simple_c("(\\d\\d):(\\d\\d):(\\d\\d)");
+	static const std::regex simple_a("(\\d?\\d)");
+	static const std::regex simple_b("(\\d?\\d):(\\d\\d)");
+	static const std::regex simple_c("(\\d?\\d):(\\d\\d):(\\d\\d)");
 	// ISO 8601 duration parsing (by https://github.com/sigidagi).
 	static const std::regex has_time_component("^((?!T).)*$");
 	static const std::regex without_time("P([[:d:]]+Y)?([[:d:]]+M)?([[:d:]]+D)?");

--- a/src/osm_profile.cpp
+++ b/src/osm_profile.cpp
@@ -1,4 +1,5 @@
 #include <routingkit/osm_profile.h>
+#include <routingkit/parse_duration.h>
 
 namespace RoutingKit{
 
@@ -430,9 +431,12 @@ unsigned get_osm_way_speed(uint64_t osm_way_id, const TagMap&tags, std::function
 		return 20;
 	}
 
-	// TODO: a ferry may have a duration tag
 	auto route = tags["route"];
 	if(route && str_eq(route, "ferry")) {
+		auto duration = tags["duration"];
+		if (duration) {
+			return ABSOLUTE_TIME | parse_duration(duration);
+		}
 		return 5;
 	}
 

--- a/src/osm_simple.cpp
+++ b/src/osm_simple.cpp
@@ -51,9 +51,13 @@ SimpleOSMCarRoutingGraph simple_load_osm_car_routing_graph_from_pbf(
 
 	ret.travel_time = ret.geo_distance;
 	for(unsigned a=0; a<ret.travel_time.size(); ++a){
-		ret.travel_time[a] *= 18000;
-		ret.travel_time[a] /= way_speed[routing_graph.way[a]];
-		ret.travel_time[a] /= 5;
+		if (ABSOLUTE_TIME & way_speed[routing_graph.way[a]]) {
+				ret.travel_time[a] = ABSOLUTE_TIME  ^ way_speed[routing_graph.way[a]];
+		} else {
+				ret.travel_time[a] *= 18000;
+				ret.travel_time[a] /= way_speed[routing_graph.way[a]];
+				ret.travel_time[a] /= 5;
+		}
 	}
 
 	ret.forbidden_turn_from_arc = std::move(routing_graph.forbidden_turn_from_arc);

--- a/src/osm_simple.cpp
+++ b/src/osm_simple.cpp
@@ -52,7 +52,7 @@ SimpleOSMCarRoutingGraph simple_load_osm_car_routing_graph_from_pbf(
 	ret.travel_time = ret.geo_distance;
 	for(unsigned a=0; a<ret.travel_time.size(); ++a){
 		if (ABSOLUTE_TIME & way_speed[routing_graph.way[a]]) {
-				ret.travel_time[a] = ABSOLUTE_TIME  ^ way_speed[routing_graph.way[a]];
+				ret.travel_time[a] = (ABSOLUTE_TIME  ^ way_speed[routing_graph.way[a]]) * 1000;
 		} else {
 				ret.travel_time[a] *= 18000;
 				ret.travel_time[a] /= way_speed[routing_graph.way[a]];

--- a/src/test_parse_duration.cpp
+++ b/src/test_parse_duration.cpp
@@ -1,0 +1,20 @@
+#include <routingkit/parse_duration.h>
+#include "expect.h"
+
+using namespace RoutingKit;
+using namespace std;
+
+int main(){
+	// ISO 8601.
+	EXPECT_CMP(parse_duration("P4D"), ==, 4*24*60*60);
+	EXPECT_CMP(parse_duration("PT71M"), ==, 71*60);
+	EXPECT_CMP(parse_duration("PT5M"), ==, 5*60);
+	// Simple times.
+	EXPECT_CMP(parse_duration("15"), ==, 15*60);
+	EXPECT_CMP(parse_duration("00:15"), ==, 15*60);
+	EXPECT_CMP(parse_duration("00:15:00"), ==, 15*60);
+	EXPECT_CMP(parse_duration("05:01"), ==, 5*60*60 + 1*60);
+	// Default 10 minutes.
+	EXPECT_CMP(parse_duration("xxx"), ==, 10 * 60);
+	return expect_failed;
+}

--- a/src/test_parse_duration.cpp
+++ b/src/test_parse_duration.cpp
@@ -10,10 +10,13 @@ int main(){
 	EXPECT_CMP(parse_duration("PT71M"), ==, 71*60);
 	EXPECT_CMP(parse_duration("PT5M"), ==, 5*60);
 	// Simple times.
+	EXPECT_CMP(parse_duration("5"), ==, 5*60);
 	EXPECT_CMP(parse_duration("15"), ==, 15*60);
 	EXPECT_CMP(parse_duration("00:15"), ==, 15*60);
+	EXPECT_CMP(parse_duration("2:00"), ==, 2*60*60);
 	EXPECT_CMP(parse_duration("00:15:00"), ==, 15*60);
 	EXPECT_CMP(parse_duration("05:01"), ==, 5*60*60 + 1*60);
+	EXPECT_CMP(parse_duration("5:01"), ==, 5*60*60 + 1*60);
 	// Default 10 minutes.
 	EXPECT_CMP(parse_duration("xxx"), ==, 10 * 60);
 	return expect_failed;


### PR DESCRIPTION
I am looking to add correct way speed to ferries. Here is an idea how it could be implemented. Unfortunately it is pretty hacky because when the way callback is called the geo_disance of the way is not known yet.
Maybe someone has another suggestion how to implement this. 