### PR TITLE
Fix swap of MinIDQueue

### DIFF
--- a/include/routingkit/id_queue.h
+++ b/include/routingkit/id_queue.h
@@ -58,7 +58,6 @@ public:
 		using std::swap;
 		swap(l.id_pos, r.id_pos);
 		swap(l.heap, r.heap);
-		swap(l.heap, r.heap);
 		swap(l.heap_size, r.heap_size);
 	}
 


### PR DESCRIPTION
Swapping two MinIDQueue's swapped their heaps twice, i.e., not at all.