### PR TITLE
make is_input_arc_upward a local variable

### DIFF
--- a/include/routingkit/customizable_contraction_hierarchy.h
+++ b/include/routingkit/customizable_contraction_hierarchy.h
@@ -46,7 +46,6 @@ struct CustomizableContractionHierarchy{
 	std::vector<unsigned>down_to_up;
 	
 	std::vector<unsigned>input_arc_to_cch_arc;
-	BitVector is_input_arc_upward;
 
 	BitVector does_cch_arc_have_input_arc;
 	LocalIDMapper does_cch_arc_have_input_arc_mapper;

--- a/src/customizable_contraction_hierarchy.cpp
+++ b/src/customizable_contraction_hierarchy.cpp
@@ -329,12 +329,11 @@ CustomizableContractionHierarchy::CustomizableContractionHierarchy(
 		timer = -get_micro_time();
 	}
 
+	BitVector is_input_arc_upward(input_arc_count, false);
 	if(cch_arc_count == 0){
 		input_arc_to_cch_arc.resize(input_arc_count, invalid_id);
-		is_input_arc_upward.resize(input_arc_count, false);
 	}else{
 		input_arc_to_cch_arc.resize(input_arc_count);
-		is_input_arc_upward.resize(input_arc_count, false);
 
 		{
 			unsigned cch_up_arc = 0;


### PR DESCRIPTION
See #82 for details.

If this passes Travis and there are no objects for some time, then I'll merge it. 