### PR TITLE
Fix build with g++-13

### DIFF
--- a/src/buffered_asynchronous_reader.cpp
+++ b/src/buffered_asynchronous_reader.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <assert.h>
 #include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace RoutingKit{

--- a/src/osm_graph_builder.cpp
+++ b/src/osm_graph_builder.cpp
@@ -11,7 +11,7 @@
 #include <routingkit/osm_decoder.h>
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <stdio.h>
 #include <memory>


### PR DESCRIPTION
When building with gcc 13, it failed unless I added these includes.